### PR TITLE
add support to disable and re-enable timers by notification

### DIFF
--- a/MMM-ProfileSwitcher.js
+++ b/MMM-ProfileSwitcher.js
@@ -165,6 +165,12 @@ Module.register("MMM-ProfileSwitcher", {
             this.sendNotification("CHANGED_PROFILE", {to: this.config.defaultClass});
         } else if (notification === "CURRENT_PROFILE") {
             this.change_profile(payload);
+        } else if (notification === "DISABLE_PROFILE_TIMERS"){
+            clearTimeout(this.timer);
+        } else if (notification === "REENABLE_PROFILE_TIMERS"){
+            if (this.config.timers && this.config.timers[this.current_profile]){
+                this.set_timer(this.config.timers[this.current_profile]);
+            }
         }
     },
 

--- a/MMM-ProfileSwitcher.js
+++ b/MMM-ProfileSwitcher.js
@@ -167,7 +167,7 @@ Module.register("MMM-ProfileSwitcher", {
             this.change_profile(payload);
         } else if (notification === "DISABLE_PROFILE_TIMERS"){
             clearTimeout(this.timer);
-        } else if (notification === "REENABLE_PROFILE_TIMERS"){
+        } else if (notification === "ENABLE_PROFILE_TIMERS"){
             if (this.config.timers && this.config.timers[this.current_profile]){
                 this.set_timer(this.config.timers[this.current_profile]);
             }

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Go to the module's main file `localtransport.js` and replace the occurences of `
 
 ## Notes For Other Developers
 * A `CHANGED_PROFILE` notifcation will be send after the `current_user` was modified.
+* The timers can be disabled/enabled by sending an `DISABLE_PROFILE_TIMERS` / `ENABLE_PROFILE_TIMERS` notifcation with an empty payload.
 
 
 ## The MIT License (MIT)


### PR DESCRIPTION
My MMM-Screen-Powersave-Notifcation module provides support to hide/show modules instead of turning off/on the display to help people with displays that can not be turned off by command.
The problem is, if the modules are hidden and a timed profile change happens things get messed up.
The idea is to send an notification to display the timers when the modules are get hidden and re-enable the timers if they are shown.